### PR TITLE
Separate app deploy from Terraform

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -41,6 +41,8 @@
   - Terraform Backend configured for Azure Blob Storage with Azure AD authentication
   - Terraform Workspaces enabled for environment separation (dev, staging, prod)
   - Dynamic image versioning via `app_version` variable
+  - Container App image tag changes ignored via lifecycle configuration
+  - Decoupled infrastructure changes from application deployment
 - **✅ Frontend Nginx proxy configured for backend communication in ACA.**
 - **✅ Verified application connectivity in Azure Container Apps.**
 - **Security**:
@@ -54,6 +56,10 @@
   - Tags images with Semantic Versioning (`-v` flag)
   - Pushes images to the correct ACR based on Terraform workspace (`-w` flag)
   - Authenticates to ACR using Azure CLI (`az acr login`)
+- **✅ Application Deployment Scripts:**
+  - `scripts/update_container_app_image.sh`: Updates a single Container App's image using Azure CLI
+  - `scripts/deploy_app.sh`: Updates both frontend and backend images to a specified version
+  - Enables application updates without requiring infrastructure changes
 
 ## 🔄 In Progress
 
@@ -142,3 +148,8 @@ The immediate next steps are planning and implementing the CI/CD pipeline (Phase
 - **Introduced Security Headers**:
     - Content Security Policy (CSP) with different configurations for development (meta tag) and production (Nginx header) to bolster application security.
     - `X-Content-Type-Options: nosniff` added via Nginx to prevent MIME sniffing.
+- **Separated Infrastructure from Application Deployment**:
+    - Modified Terraform to ignore image tag changes in Container Apps
+    - Made app_version variable optional with sensible defaults
+    - Created simplified Azure CLI scripts for container image updates
+    - Established clear separation of concerns between infrastructure management and application releases

--- a/plans/implementation-plan.md
+++ b/plans/implementation-plan.md
@@ -107,15 +107,14 @@ Develop a web app providing interactive map-based visualizations and correlation
   - [x] Implement `azurerm_dns_cname_record` in the module to point the custom hostname to the app (for subdomains).
   - [x] Terraform now fully automates this process if `frontend_custom_hostname` and Azure DNS details are provided.
 
-#### Secrets and Environment Management
-- [ ] Configure environment variables securely
-  - [ ] Setup Azure Key Vault for secrets management
-  - [ ] Configure environment variable injection into containers
-  - [ ] Ensure proper separation of dev/staging/prod environments
+#### Separate application release from Terraform infrastructure code
+- [x] Release app without running `terraform apply`
+  - [x] Modify `container_apps` module to ignore image tag changes to frontend & backend
+  - [x] Create alternate way to change the image tag in Azure Container apps without TF
 
 #### CI/CD Pipeline
 - [ ] Setup automated build and deployment
-  - [ ] Create GitHub Actions or Azure DevOps pipeline
+  - [ ] Create GitHub Actions pipeline
   - [ ] Configure build, test, and deployment stages
   - [ ] Set up automated testing before deployment
 
@@ -130,11 +129,17 @@ Develop a web app providing interactive map-based visualizations and correlation
   - [ ] Conduct performance tests (loading speed, API latency)
   - [ ] Test on multiple browsers and devices
 
+#### Secrets and Environment Management
+- [ ] Configure environment variables securely
+  - [ ] Setup Azure Key Vault for secrets management
+  - [ ] Configure environment variable injection into containers
+  - [ ] Ensure proper separation of dev/staging/prod environments
+
 ### Deliverables
 - [x] Containerized applications (frontend and backend)
 - [x] Docker Compose configuration for local development
 - [x] Infrastructure as Code templates for reproducible environments
-- [ ] Publicly accessible, functional MVP web application
+- [x] Publicly accessible, functional MVP web application
 - [ ] CI/CD pipeline for automated deployments
 
 ---

--- a/scripts/deploy_app.sh
+++ b/scripts/deploy_app.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+
+# Help text function
+show_help() {
+  echo "Usage: $0 -g RESOURCE_GROUP -p PROJECT_NAME -e ENVIRONMENT -v VERSION -r REGISTRY_URL [-h]"
+  echo
+  echo "Deploys a new version of the application by updating frontend and backend container apps"
+  echo
+  echo "Options:"
+  echo "  -g    Resource group name containing the Container Apps"
+  echo "  -p    Project name prefix used in the container app names"
+  echo "  -e    Environment (dev, staging, prod)"
+  echo "  -v    Version tag to deploy (e.g., v1.2.3)"
+  echo "  -r    ACR registry URL (e.g., myacr.azurecr.io)"
+  echo "  -h    Show this help message"
+  echo
+  echo "Example:"
+  echo "  $0 -g myproject-prod-rg -p myproject -e prod -v v1.2.3 -r myacr.azurecr.io"
+}
+
+# Parse arguments
+while getopts "g:p:e:v:r:h" opt; do
+  case $opt in
+    g) RESOURCE_GROUP="$OPTARG" ;;
+    p) PROJECT_NAME="$OPTARG" ;;
+    e) ENVIRONMENT="$OPTARG" ;;
+    v) VERSION="$OPTARG" ;;
+    r) REGISTRY_URL="$OPTARG" ;;
+    h) show_help; exit 0 ;;
+    *) show_help; exit 1 ;;
+  esac
+done
+
+# Validate required parameters
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$PROJECT_NAME" ] || [ -z "$ENVIRONMENT" ] || [ -z "$VERSION" ] || [ -z "$REGISTRY_URL" ]; then
+  echo "Error: Missing required parameters"
+  show_help
+  exit 1
+fi
+
+# Set app names based on naming convention
+FRONTEND_APP_NAME="${PROJECT_NAME}-${ENVIRONMENT}-frontend"
+BACKEND_APP_NAME="${PROJECT_NAME}-${ENVIRONMENT}-backend"
+
+# Set image references
+FRONTEND_IMAGE="${REGISTRY_URL}/${PROJECT_NAME}/frontend:${VERSION}"
+BACKEND_IMAGE="${REGISTRY_URL}/${PROJECT_NAME}/backend:${VERSION}"
+
+# Ensure the update_container_app_image.sh script exists and is executable
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+UPDATE_SCRIPT="${SCRIPT_DIR}/update_container_app_image.sh"
+
+if [ ! -f "$UPDATE_SCRIPT" ] || [ ! -x "$UPDATE_SCRIPT" ]; then
+  echo "Error: update_container_app_image.sh script not found or not executable"
+  echo "Expected location: $UPDATE_SCRIPT"
+  exit 1
+fi
+
+# Update the frontend app
+echo "=== Updating frontend app ==="
+"$UPDATE_SCRIPT" -g "$RESOURCE_GROUP" -n "$FRONTEND_APP_NAME" -i "$FRONTEND_IMAGE"
+
+# Update the backend app
+echo -e "\n=== Updating backend app ==="
+"$UPDATE_SCRIPT" -g "$RESOURCE_GROUP" -n "$BACKEND_APP_NAME" -i "$BACKEND_IMAGE"
+
+echo -e "\n=== Deployment completed successfully ==="
+echo "Frontend image: $FRONTEND_IMAGE"
+echo "Backend image: $BACKEND_IMAGE" 

--- a/scripts/update_container_app_image.sh
+++ b/scripts/update_container_app_image.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+# Help text function
+show_help() {
+  echo "Usage: $0 -g RESOURCE_GROUP -n APP_NAME -i IMAGE_REFERENCE [-h]"
+  echo
+  echo "Updates an Azure Container App with a new container image reference using the --image flag."
+  echo
+  echo "Options:"
+  echo "  -g    Resource group name containing the Container App"
+  echo "  -n    Container App name to update"
+  echo "  -i    Full image reference (e.g. myacr.azurecr.io/myapp/backend:v1.2.3)"
+  echo "  -h    Show this help message"
+  echo
+  echo "Example:"
+  echo "  $0 -g myproject-prod-rg -n myproject-prod-frontend -i myacr.azurecr.io/myproject/frontend:v1.2.3"
+}
+
+# Parse arguments
+while getopts "g:n:i:h" opt; do
+  case $opt in
+    g) RESOURCE_GROUP="$OPTARG" ;;
+    n) APP_NAME="$OPTARG" ;;
+    i) IMAGE_REFERENCE="$OPTARG" ;;
+    h) show_help; exit 0 ;;
+    *) show_help; exit 1 ;;
+  esac
+done
+
+# Validate required parameters
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$APP_NAME" ] || [ -z "$IMAGE_REFERENCE" ]; then
+  echo "Error: Missing required parameters"
+  show_help
+  exit 1
+fi
+
+echo "Updating Container App '$APP_NAME' in resource group '$RESOURCE_GROUP'"
+echo "New image: $IMAGE_REFERENCE"
+
+# Ensure the user is logged in to Azure
+if ! az account show &>/dev/null; then
+  echo "You are not logged in to Azure. Please run 'az login' first."
+  exit 1
+fi
+
+# Apply the updated image directly
+echo "Applying the updated image to the Container App..."
+az containerapp update \
+  --name "$APP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --image "$IMAGE_REFERENCE"
+
+echo "Container App '$APP_NAME' successfully updated with image: $IMAGE_REFERENCE" 

--- a/tf/modules/container_apps/main.tf
+++ b/tf/modules/container_apps/main.tf
@@ -15,6 +15,9 @@ locals {
   txt_record_name   = local.record_prefix != null ? (local.record_prefix == "" ? "asuid" : "asuid.${local.record_prefix}") : null
 
   frontend_app_name = "${var.project_name}-${var.environment}-frontend"
+
+  # Default app version to "latest" if null or empty
+  effective_app_version = var.app_version != null ? var.app_version : "latest"
 }
 
 resource "azurerm_log_analytics_workspace" "logs" {
@@ -79,7 +82,7 @@ resource "azurerm_container_app" "frontend" {
   template {
     container {
       name   = "frontend"
-      image  = "${var.acr_login_server}/${var.project_name}/frontend:${var.app_version}"
+      image  = "${var.acr_login_server}/${var.project_name}/frontend:${local.effective_app_version}"
       cpu    = 0.5
       memory = "1Gi"
 
@@ -90,6 +93,12 @@ resource "azurerm_container_app" "frontend" {
     }
     min_replicas = 1
     max_replicas = 5
+  }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].container[0].image,
+    ]
   }
 }
 
@@ -125,7 +134,7 @@ resource "azurerm_container_app" "backend" {
   template {
     container {
       name   = "backend"
-      image  = "${var.acr_login_server}/${var.project_name}/backend:${var.app_version}"
+      image  = "${var.acr_login_server}/${var.project_name}/backend:${local.effective_app_version}"
       cpu    = 0.5
       memory = "1Gi"
 
@@ -147,6 +156,12 @@ resource "azurerm_container_app" "backend" {
     }
     min_replicas = 1
     max_replicas = 3
+  }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].container[0].image,
+    ]
   }
 }
 

--- a/tf/modules/container_apps/variables.tf
+++ b/tf/modules/container_apps/variables.tf
@@ -45,8 +45,10 @@ variable "subnet_id" {
 }
 
 variable "app_version" {
-  description = "The version tag of the app images to deploy"
+  description = "The version tag of the app images to deploy. For initial deployment only, updates should use the deploy scripts."
   type        = string
+  nullable    = true
+  default     = "latest"
 }
 
 variable "dns_zone_name" {

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -34,10 +34,11 @@ variable "acr_sku" {
 }
 
 variable "app_version" {
-  description = "The semantic version tag of the application images to deploy (e.g., 1.0.0)."
+  description = "The semantic version tag of the application images to deploy (e.g., 1.0.0). Only needed for initial deployment; subsequent image updates should use the deploy_app.sh script."
   type        = string
-  # No default - this should be explicitly set per deployment
-  # Example: set in terraform.tfvars or via -var="app_version=1.0.0"
+  nullable    = true
+  default     = null
+  # No longer mandatory for infrastructure-only changes
 }
 
 variable "container_apps_environment_infrastructure_subnet_id" {


### PR DESCRIPTION
Rather than coupling infrastructure and app changes together in Terraform, create scripts for deploying the app without Terraform. This way, infrastructure and app version changes can be made in separate steps.